### PR TITLE
Fixed invalid version string

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=LIDAR-Lite v3
-version=v1.0.2
+version=1.0.2
 author=Garmin <www.garmin.com>
 maintainer=Garmin <www.garmin.com>
 sentence=Arduino library for LIDAR-Lite v3.


### PR DESCRIPTION
The version string in the `library.properties` file had a `v` prefix which caused the Arduino IDE to show an invalid version warning. This goes away if you stick to the `x.y.z` version format with no other characters.